### PR TITLE
Update prestashop-nginx.conf

### DIFF
--- a/prestashop-nginx.conf
+++ b/prestashop-nginx.conf
@@ -133,7 +133,6 @@ server {
         fastcgi_keep_conn on;
         fastcgi_read_timeout 30s;
         fastcgi_send_timeout 30s;
-        fastcgi_read_timeout 300;
 
         # In case of long loading or 502 / 504 errors
         # fastcgi_buffer_size 256k;


### PR DESCRIPTION
Removed `fastcgi_read_timeout 300;` due to `nginx -t` found duplicate values